### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/files.yml
+++ b/.github/workflows/files.yml
@@ -1,5 +1,9 @@
 name: List Files and Upload Artifact
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/EventsGallery/security/code-scanning/4](https://github.com/Xieons-Gaming-Corner/EventsGallery/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow only needs to read repository contents and upload artifacts, we will set `contents: read` and `actions: read`. These permissions are sufficient for the `actions/checkout` and `actions/upload-artifact` steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
