### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/list_files.yml
+++ b/.github/workflows/list_files.yml
@@ -1,5 +1,9 @@
 name: List Files and Upload Artifact
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/EventsGallery/security/code-scanning/1](https://github.com/Xieons-Gaming-Corner/EventsGallery/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow only needs to read repository contents and upload an artifact, we will set `contents: read` and `actions: read`. These permissions are sufficient for the `actions/checkout` and `actions/upload-artifact` actions used in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
